### PR TITLE
Supported languages should not be left empty in a table.

### DIFF
--- a/tables/compose.txt
+++ b/tables/compose.txt
@@ -33,7 +33,7 @@ NAME = Compose
 ### The local names of this table 
 
 ### Supported languages of this table
-LANGUAGES = 
+LANGUAGES = other
 
 AUTHOR = Yu Yuwei <yu-yuwei@xmu.edu.cn> 
 

--- a/tables/latex.txt
+++ b/tables/latex.txt
@@ -32,7 +32,7 @@ DESCRIPTION = Use LaTeX input keystrokes to input lots of symbols.
 AUTHOR = Somebody unknown
 
 ### Supported locales of this table
-LANGUAGES = 
+LANGUAGES = other
 
 ### Prompt string to be displayed in the status area.
 STATUS_PROMPT = Σ

--- a/tables/mathwriter-ibus.txt
+++ b/tables/mathwriter-ibus.txt
@@ -8,7 +8,7 @@ SERIAL_NUMBER = 20100505
 
 NAME = mathwriter
 
-LANGUAGES = 
+LANGUAGES = other
 STATUS_PROMPT = Σ
 
 icon = mathwriter.png


### PR DESCRIPTION
For an input method which has LANGUAGES set to an empty string,
nothing at all is shown by ibus when trying to change to that input
method using the trigger key which makes the input method hard to
select.

See: https://bugzilla.redhat.com/show_bug.cgi?id=855102
