### PR TITLE
Set symbols to be displayed in IM switchers

### DIFF
--- a/tables/compose.txt
+++ b/tables/compose.txt
@@ -27,6 +27,9 @@ DESCRIPTION = Mimic Compose Key input
 ### ICON 
 ICON = compose.svg
 
+### The symbol to be displayed in IM switchers
+SYMBOL = Ć
+
 ### The default name of this table
 NAME = Compose
 

--- a/tables/ipa-x-sampa.txt
+++ b/tables/ipa-x-sampa.txt
@@ -26,6 +26,9 @@ SERIAL_NUMBER = 20050425
 
 ICON = ipa-x-sampa.svg
 
+### The symbol to be displayed in IM switchers
+SYMBOL = ə
+
 ### The default name of this table
 NAME = IPA-X-SAMPA
 

--- a/tables/latex.txt
+++ b/tables/latex.txt
@@ -22,6 +22,9 @@ LICENSE = LGPL
 
 ICON = latex.svg
 
+### The symbol to be displayed in IM switchers
+SYMBOL = ∑
+
 ### The default name of this table
 NAME = LaTeX
 

--- a/tables/thai.txt
+++ b/tables/thai.txt
@@ -18,6 +18,9 @@ SERIAL_NUMBER = 20050908
 
 ICON = thai.png
 
+### The symbol to be displayed in IM switchers
+SYMBOL = ก
+
 ### The default name of this table
 NAME = Thai
 

--- a/tables/yawerty.txt
+++ b/tables/yawerty.txt
@@ -18,6 +18,9 @@ SERIAL_NUMBER = 20040403
 
 ICON = yawerty.png
 
+### The symbol to be displayed in IM switchers
+SYMBOL = Я
+
 ### The default name of this table
 NAME = Yawerty
 


### PR DESCRIPTION
An attempt has been made to match the icon for each table. Not all tables have been touched; where the icon did not have a clear relationship to a single Unicode character, no change has been made.
