### PR TITLE
Extend russian translit for latin slavic layouts

### DIFF
--- a/tables/translit.txt
+++ b/tables/translit.txt
@@ -19,7 +19,7 @@ UUID = e39c975a-262b-4ad3-b9b8-15c5ff211e4e
 ### A unique number indicates the version of this file.
 ### For example the last modified date of this file.
 ### This number must be less than 2^32.
-SERIAL_NUMBER = 20130202
+SERIAL_NUMBER = 20161105
 
 ICON = translit.svg
 
@@ -93,7 +93,7 @@ DEF_FULL_WIDTH_LETTER = FALSE
 MAX_KEY_LENGTH = 3
 
 ### Valid input chars.
-VALID_INPUT_CHARS = ABCDEFGHIJKLMNOPRSTUVWYZÄÖÜabcdefghijklmnopqrstuvwxyzäöü'#
+VALID_INPUT_CHARS = ABCDEFGHIJKLMNOPRSTUVWYZÄÖÜÁÉÚČĆŠŚŻŽabcdefghijklmnopqrstuvwxyzäöüáéúćčśšżž'#
 
 ### The key strokes to split inputted string.
 ###SPLIT_KEYS = quoteright
@@ -128,6 +128,8 @@ JO	Ё	1000
 Yo	Ё	1000
 YO	Ё	1000
 Ö	Ё	1000
+Ž	Ж	1000
+Ż	Ж	1000
 Zh	Ж	1000
 ZH	Ж	1000
 Z	З	1000
@@ -149,13 +151,23 @@ X	Х	1000
 C	Ц	1000
 Ch	Ч	1000
 CH	Ч	1000
+Č	Ч	1000
+Ć	Ч	1000
 Sh	Ш	1000
 SH	Ш	1000
 W	Ш	1000
 Shh	Щ	1000
 SHH	Щ	1000
+Š	Ш	1000
+Ś	Ш	1000
 Sj	Щ	1000
 SJ	Щ	1000
+Šh	Щ	1000
+ŠH	Щ	1000
+Šč	Щ	1000
+ŠČ	Щ	1000
+Ść	Щ	1000
+ŚĆ	Щ	1000
 ##	Ъ	1000
 Y	Ы	1000
 ''	Ь	1000
@@ -163,15 +175,18 @@ Je	Э	1000
 JE	Э	1000
 Ä	Э	1000
 E'	Э	1000
+É	Э	1000
 Ju	Ю	1000
 JU	Ю	1000
 Yu	Ю	1000
 YU	Ю	1000
 Ü	Ю	1000
+Ú	Ю	1000
 Ja	Я	1000
 JA	Я	1000
 Ya	Я	1000
 YA	Я	1000
+Á	Я	1000
 Q	Я	1000
 a	а	1000
 b	б	1000
@@ -182,6 +197,8 @@ e	е	1000
 jo	ё	1000
 yo	ё	1000
 ö	ё	1000
+ž	ж	1000
+ż	ж	1000
 zh	ж	1000
 z	з	1000
 i	и	1000
@@ -201,20 +218,30 @@ h	х	1000
 x	х	1000
 c	ц	1000
 ch	ч	1000
+č	ч	1000
+ć	ч	1000
 sh	ш	1000
 w	ш	1000
+š	ш	1000
+ś	ш	1000
 shh	щ	1000
 sj	щ	1000
+šh	щ	1000
+šč	щ	1000
+ść	щ	1000
 #	ъ	1000
 y	ы	1000
 '	ь	1000
 je	э	1000
 e'	э	1000
 ä	э	1000
+é	э	1000
 ju	ю	1000
 yu	ю	1000
 ü	ю	1000
+ú	ю	1000
 ja	я	1000
 ya	я	1000
 q	я	1000
+á	я	1000
 END_TABLE


### PR DESCRIPTION
I added several entries to the russian translit table in order to make them more usable on western and (latin) southern slavic layouts (such as czech, polish, slovak, serbocroatian etc.).
Most notably, the equivalent latin characters such as š, ž, č are now recognized.