### PR TITLE
Use correct angle brackets

### DIFF
--- a/tables/latex.txt
+++ b/tables/latex.txt
@@ -622,8 +622,10 @@ _x	ₓ	0
 \flat	♭	0
 \natural	♮	0
 \sharp	♯	0
-\langle	〈	0
-\rangle	〉	0
+\langle	⟨	0
+\rangle	⟩	0
+\llangle	⟪	0
+\rrangle	⟫	0
 \llbracket	⟦	0
 \rrbracket	⟧	0
 \llparenthesis	⦇	0


### PR DESCRIPTION
`\langle` and `\rangle` were previously U+2329, U+232A from Miscellaneous Technical. Changing them to U+27E8, U+27E9 from Miscellaneous Mathematical Symbols-A makes more sense and lets us also add the double angle brackets U+27EA, U+27EB.